### PR TITLE
Containerize the application

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,17 @@
+# files
+**/.DS_Store
+**/README.md
+**/.gitignore
+
+# file types
+**/*.log
+
+# directories
+**/__pycache__
+**/*.egg-info
+.mypy_cache
+doc
+test
+venv
+.github
+.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM python:3.12-rc-slim-bookworm
+SHELL ["/bin/bash", "-c"]
+ENV DEBIAN_FRONTEND=noninteractive
+ENV PIP_ROOT_USER_ACTION=ignore
+ENV PYTHONDONTWRITEBYTECODE 1
+ENV PYTHONUNBUFFERED 1
+
+# Install base tools
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    git=1:2.39.2-1.1 \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
+RUN python -m pip install --no-cache-dir --upgrade pip==24.1
+
+WORKDIR /app
+COPY . .
+
+RUN python -m pip install --no-cache-dir .
+
+ENTRYPOINT ["aqctl_thorlabs_cube"]
+CMD ["-p", "3255", "--product", "kdc101", "--device", "/dev/ttyUSBx", "--bind", "*"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,4 +17,4 @@ COPY . .
 RUN python -m pip install --no-cache-dir .
 
 ENTRYPOINT ["aqctl_thorlabs_cube"]
-CMD ["-p", "3255", "--product", "kdc101", "--device", "/dev/ttyUSBx", "--bind", "*"]
+CMD ["-p", "3255", "-P", "kdc101", "-d", "/dev/ttyUSB0", "--bind", "*"]

--- a/README.md
+++ b/README.md
@@ -3,23 +3,30 @@
 Derived from the [thorlabs_tcube](https://github.com/m-labs/thorlabs_tcube) package.
 
 ## Installation
-Clone the repository then install using pip:
+Clone the repository then install using [pip](https://pip.pypa.io/en/stable/installation/):
 ```sh
 $ git clone git@github.com:quantumion/thorlabs_cube.git
 $ cd thorlabs_cube
 $ pip install .
 ```
 
-Optionally, install with Sphinx to build autodocumentation:
+Optionally, install with [Sphinx](https://www.sphinx-doc.org/) to build autodocumentation:
 ```sh
 $ pip install .[docs]
+```
+
+### Docker Container
+Build and launch the application as a service in a container with [Docker Compose](https://docs.docker.com/compose/):
+```sh
+$ docker compose build
+$ docker compose up -d
 ```
 
 ## Usage
 See the [documentation](/doc/index.rst) for setup and usage instructions.
 
 ## Documentation
-Build the documentation with Sphinx:
+Build the documentation with [Sphinx](https://www.sphinx-doc.org/):
 ```sh
 $ cd doc
 $ make html

--- a/compose.yml
+++ b/compose.yml
@@ -1,10 +1,12 @@
-# builds and runs the wavemeter control container
+# builds and runs the thorlabs t/kcube control services
 services:
   thorlabs_cube:
     container_name: kdc101
-    restart: always
+    # restart: always
     ports:
       - 3255:3255
+    devices:
+     - /dev/ttyUSB0:/dev/ttyUSB0
     networks:
       - motor
     build:
@@ -12,7 +14,7 @@ services:
       dockerfile: ./Dockerfile
     # to run in simulation mode, include "--simulation" in the entrypoint command after port number
     entrypoint: [ "aqctl_thorlabs_cube"]
-    command: ["-p", "3255", "--product", "kdc101", "--device", "/dev/ttyUSBx", "--bind", "*", "--simulation"]
+    command: ["-p", "3255", "-P", "kdc101", "-d", "/dev/ttyUSB0", "--bind", "*"]
 
 networks:
   motor:

--- a/compose.yml
+++ b/compose.yml
@@ -8,7 +8,7 @@ services:
     ports:
       - 3255:3255
     devices:
-     - /dev/ttyUSB0:/dev/ttyUSB0
+     - /dev/kdc101_z:/dev/ttyUSB0
     networks:
       - thorlabs_cube
     build:
@@ -24,7 +24,7 @@ services:
     ports:
       - 3256:3255
     devices:
-     - /dev/ttyUSB1:/dev/ttyUSB0
+     - /dev/kdc101_y:/dev/ttyUSB0
     networks:
       - thorlabs_cube
     build:

--- a/compose.yml
+++ b/compose.yml
@@ -1,0 +1,18 @@
+# builds and runs the wavemeter control container
+services:
+  thorlabs_cube:
+    container_name: kdc101
+    restart: always
+    ports:
+      - 3255:3255
+    networks:
+      - motor
+    build:
+      context: ./
+      dockerfile: ./Dockerfile
+    # to run in simulation mode, include "--simulation" in the entrypoint command after port number
+    entrypoint: [ "aqctl_thorlabs_cube"]
+    command: ["-p", "3255", "--product", "kdc101", "--device", "/dev/ttyUSBx", "--bind", "*", "--simulation"]
+
+networks:
+  motor:

--- a/compose.yml
+++ b/compose.yml
@@ -1,14 +1,16 @@
 # builds and runs the thorlabs t/kcube control services
+name: ablation_aim
+
 services:
-  thorlabs_cube:
-    container_name: kdc101
-    # restart: always
+  z_control:
+    container_name: kdc101_z
+    restart: always
     ports:
       - 3255:3255
     devices:
      - /dev/ttyUSB0:/dev/ttyUSB0
     networks:
-      - motor
+      - thorlabs_cube
     build:
       context: ./
       dockerfile: ./Dockerfile
@@ -16,5 +18,20 @@ services:
     entrypoint: [ "aqctl_thorlabs_cube"]
     command: ["-p", "3255", "-P", "kdc101", "-d", "/dev/ttyUSB0", "--bind", "*"]
 
+  y_control:
+    container_name: kdc101_y
+    restart: always
+    ports:
+      - 3256:3255
+    devices:
+     - /dev/ttyUSB1:/dev/ttyUSB0
+    networks:
+      - thorlabs_cube
+    build:
+      context: ./
+      dockerfile: ./Dockerfile
+    entrypoint: [ "aqctl_thorlabs_cube"]
+    command: ["-p", "3255", "-P", "kdc101", "-d", "/dev/ttyUSB0", "--bind", "*"]
+
 networks:
-  motor:
+  thorlabs_cube:

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -79,17 +79,8 @@ First, run the KDC101 controller::
     On Windows the serial port (the ``-d`` argument) will be of the form ``COMx``.
 
 .. note::
-    Anything compatible with `serial_for_url <http://pyserial.sourceforge.net/pyserial_api.html#serial.serial_for_url>`_
-    can be given as a device in ``-d`` argument.
-
-    For instance, if you want to specify the Vendor/Product ID and the USB Serial Number, you can do:
-
-    ``-d "hwgrep://<VID>:<PID> SNR=<serial_number>"``.
-    for instance:
-
-    ``-d "hwgrep://0403:faf0 SNR=83852734"``
-
-    The hwgrep URL works on both Linux and Windows.
+    See above for how to specify the USB Serial Number of the device instead of the
+    /dev/ttyUSBx (or the COMx name).
 
 Then, send commands to it via the ``artiq_rpctool`` utility::
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 setup(
     name="thorlabs_cube",
     install_requires=[
-        "sipyco@git+ssh://git@github.com/m-labs/sipyco.git",
+        "sipyco@git+https://github.com/m-labs/sipyco.git",
         "asyncserial",
         "numpy", # hidden sipyco dependency
     ],


### PR DESCRIPTION
Add support for deploying as an application with services for multiple motor controllers.

- Add Dockerfile, compose file, and .dockerignore
- Minor changes to documentation

Tested on hardware successfully. Depends on #5. Closes #2.