### PR TITLE
resolve async error on program shutdown

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ setup(
     description="ARTIQ controller for Thorlabs T/KCube devices",
     install_requires=[
         "sipyco@git+https://github.com/m-labs/sipyco.git@v1.7",
-        "asyncserial==0.1.0",
+        "asyncserial@git+https://github.com/xvzf/asyncserial-py.git@1498bbc",
         "numpy==2.0.0",  # hidden sipyco dependency
     ],
     extras_require={

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="thorlabs_cube",
-    version="0.0.1",
+    version="0.0.2",
     url="https://github.com/quantumion/thorlabs_cube",
     description="ARTIQ controller for Thorlabs T/KCube devices",
     install_requires=[

--- a/src/thorlabs_cube/aqctl_thorlabs_cube.py
+++ b/src/thorlabs_cube/aqctl_thorlabs_cube.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+"""NDSP entrypoint script that initializes the device and start the control server"""
 
 import argparse
 import asyncio
@@ -88,7 +89,7 @@ def main():
                 loop=loop,
             )
         finally:
-            dev.close()
+            loop.run_until_complete(dev.close())
     finally:
         loop.close()
 


### PR DESCRIPTION
Issue #15
-resolves problem where call to close device port was never awaited
-update [asyncserial package to untagged bug fix](https://github.com/xvzf/asyncserial-py/commit/1498bbcd442065471b34d9b1c50084cd8a37cb64)
-add event loop resolution to device close call